### PR TITLE
fix: 修复外置原生资源的路径处理

### DIFF
--- a/Assets/CatAsset/Runtime/Database/CatAssetDatabase.cs
+++ b/Assets/CatAsset/Runtime/Database/CatAssetDatabase.cs
@@ -193,10 +193,16 @@ namespace CatAsset.Runtime
                 int index = assetName.LastIndexOf('/');
                 string dir = null;
                 string name;
-                if (index >= 0)
+                if (index == 0)
+                {
+                    // 虽然不应该出现这种情况，但也先处理一下
+                    dir = "/";
+                    name = assetName.Substring(1);
+                }
+                else if (index > 0)
                 {
                     //处理多级路径
-                    dir = assetName.Substring(0, index - 1);
+                    dir = assetName.Substring(0, index);
                     name = assetName.Substring(index + 1);
                 }
                 else


### PR DESCRIPTION
修复了多级路径时，错误的截断了目录的最后一个字符问题

并且增加了一个理论上不应该出现的，资源被放置在根目录的边缘情况，这在 linux 上可能会出现，姑且先按照正常情况处理
这里也可以改成抛出异常，不接受根目录下文件读取，如果有必要的话