### PR TITLE
feat: 资源转换器重写为支持异步操作

### DIFF
--- a/Assets/CatAsset/Runtime/CatAssetManager.cs
+++ b/Assets/CatAsset/Runtime/CatAssetManager.cs
@@ -36,8 +36,8 @@ namespace CatAsset.Runtime
         /// <summary>
         /// 资源类型->自定义原生资源转换方法
         /// </summary>
-        private static Dictionary<Type, CustomRawAssetConverter> converterDict =
-            new Dictionary<Type, CustomRawAssetConverter>();
+        private static Dictionary<Type, ICustomRawAssetConverter> converterDict =
+            new Dictionary<Type, ICustomRawAssetConverter>();
 
         /// <summary>
         /// 资源加载器类型 -> 资源加载器实例
@@ -84,27 +84,27 @@ namespace CatAsset.Runtime
 
         static CatAssetManager()
         {
-            RegisterCustomRawAssetConverter(typeof(Texture2D), (bytes =>
+            RegisterCustomRawAssetConverter(bytes =>
             {
                 Texture2D texture2D = new Texture2D(0, 0);
                 texture2D.LoadImage(bytes);
                 return texture2D;
-            }));
+            });
 
-            RegisterCustomRawAssetConverter(typeof(Sprite), (bytes =>
+            RegisterCustomRawAssetConverter(bytes =>
             {
                 Texture2D texture2D = new Texture2D(0, 0);
                 texture2D.LoadImage(bytes);
                 Sprite sp = Sprite.Create(texture2D, new Rect(0, 0, texture2D.width, texture2D.height), new Vector2(0.5f,0.5f));
                 return sp;
-            }));
+            });
 
-            RegisterCustomRawAssetConverter(typeof(TextAsset), (bytes =>
+            RegisterCustomRawAssetConverter(bytes =>
             {
                 string text = Encoding.UTF8.GetString(bytes);
                 TextAsset textAsset = new TextAsset(text);
                 return textAsset;
-            }));
+            });
         }
 
         /// <summary>
@@ -159,17 +159,33 @@ namespace CatAsset.Runtime
         /// <summary>
         /// 注册自定义原生资源转换方法
         /// </summary>
-        public static void RegisterCustomRawAssetConverter(Type type, CustomRawAssetConverter converter)
+        public static void RegisterCustomRawAssetConverter(Type type, ICustomRawAssetConverter converter)
         {
             converterDict[type] = converter;
         }
 
         /// <summary>
+        /// 注册匿名同步自定义原生资源转换方法
+        /// </summary>
+        public static void RegisterCustomRawAssetConverter<T>(CustomRawAssetConverterFunc<T> converter)
+        {
+            RegisterCustomRawAssetConverter(typeof(T), CustomRawAssetConverter.Create(converter));
+        }
+
+        /// <summary>
+        /// 注册匿名异步自定义原生资源转换方法
+        /// </summary>
+        public static void RegisterAsyncCustomRawAssetConverter<T>(AsyncCustomRawAssetConverterFunc<T> converter)
+        {
+            RegisterCustomRawAssetConverter(typeof(T), CustomRawAssetConverter.CreateAsync(converter));
+        }
+
+        /// <summary>
         /// 获取自定义原生资源转换方法
         /// </summary>
-        internal static CustomRawAssetConverter GetCustomRawAssetConverter(Type type)
+        internal static ICustomRawAssetConverter GetCustomRawAssetConverter(Type type)
         {
-            converterDict.TryGetValue(type, out CustomRawAssetConverter converter);
+            converterDict.TryGetValue(type, out ICustomRawAssetConverter converter);
             return converter;
         }
         

--- a/Assets/CatAsset/Runtime/Handler/AssetHandler.cs
+++ b/Assets/CatAsset/Runtime/Handler/AssetHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace CatAsset.Runtime
@@ -11,9 +12,9 @@ namespace CatAsset.Runtime
     public delegate void AssetLoadedCallback<T>(AssetHandler<T> handler);
 
     /// <summary>
-    /// 自定义原生资源转换方法的原型
+    /// 资源转换完毕回调方法的原型
     /// </summary>
-    public delegate object CustomRawAssetConverter(byte[] bytes);
+    public delegate void AssetConvertedCallback<T>(T asset);
 
     /// <summary>
     /// 资源句柄
@@ -45,18 +46,26 @@ namespace CatAsset.Runtime
         /// <summary>
         /// 转换原始资源对象为指定类型的资源对象
         /// </summary>
-        public T AssetAs<T>()
+        public void AssetAs<T>(AssetConvertedCallback<T> onCompleted)
         {
+            if (onCompleted == null)
+            {
+                Debug.LogError("AssetAs的onCompleted回调不应该为null");
+                return;
+            }
+
             if (AssetObj == null)
             {
-                return default;
+                onCompleted.Invoke(default);
+                return;
             }
 
             Type type = typeof(T);
 
             if (type == typeof(object))
             {
-                return (T)AssetObj;
+                onCompleted.Invoke((T)AssetObj);
+                return;
             }
 
             switch (Category)
@@ -67,42 +76,65 @@ namespace CatAsset.Runtime
                         if (type == typeof(Sprite) && AssetObj is Texture2D tex)
                         {
                             Sprite sprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f,0.5f));
-                            return (T) (object) sprite;
+                            onCompleted.Invoke((T) (object) sprite);
                         }
                         else if (type == typeof(Texture2D) && AssetObj is Sprite sprite)
                         {
-                            return (T) (object) sprite.texture;
+                            onCompleted.Invoke((T) (object) sprite.texture);
                         }
                         else
                         {
-                            return (T)AssetObj;
+                            onCompleted.Invoke((T)AssetObj);
                         }
+
+                        return;
                     }
 
                     Debug.LogError($"AssetHandler.AssetAs获取失败，资源类别为{Category}，但是T为{type}");
-                    return default;
+                    onCompleted.Invoke(default);
+                    return;
 
                 case AssetCategory.InternalRawAsset:
                 case AssetCategory.ExternalRawAsset:
 
                     if (type == typeof(byte[]))
                     {
-                        return (T)AssetObj;
+                        onCompleted.Invoke((T)AssetObj);
+                        return;
                     }
 
-                    CustomRawAssetConverter converter = CatAssetManager.GetCustomRawAssetConverter(type);
+                    ICustomRawAssetConverter converter = CatAssetManager.GetCustomRawAssetConverter(type);
                     if (converter == null)
                     {
                         Debug.LogError($"AssetHandler.AssetAs获取失败，没有注册类型{type}的CustomRawAssetConverter");
-                        return default;
+                        onCompleted.Invoke(default);
+                        return;
                     }
 
-                    object convertedAsset = converter((byte[]) AssetObj);
-                    return (T) convertedAsset;
-
+                    var task = converter.Convert((byte[]) AssetObj);
+                    if (task.IsCompleted)
+                    {
+                        HandleCustomRawAssetConvertTask(task);
+                    }
+                    else
+                    {
+                        task.ContinueWith(HandleCustomRawAssetConvertTask, TaskScheduler.FromCurrentSynchronizationContext());
+                    }
+                    return;
             }
 
-            return default;
+            void HandleCustomRawAssetConvertTask(Task<object> task)
+            {
+                if (task.IsCompletedSuccessfully)
+                {
+                    onCompleted.Invoke((T) task.Result);
+                }
+                else
+                {
+                    onCompleted.Invoke(default);
+                }
+            }
+
         }
 
         public override void Clear()
@@ -169,11 +201,13 @@ namespace CatAsset.Runtime
             AssetObj = loadedAsset;
             State = AssetObj != null ? HandlerState.Success : HandlerState.Failed;
 
-            Asset = AssetAs<T>();
-            
-            CheckError();
-            onLoadedCallback?.Invoke(this);
-            AsyncStateMachineMoveNext?.Invoke();
+            AssetAs<T>(asset =>
+            {
+                Asset = asset;
+                CheckError();
+                onLoadedCallback?.Invoke(this);
+                AsyncStateMachineMoveNext?.Invoke(); 
+            });
         }
 
         /// <summary>

--- a/Assets/CatAsset/Runtime/Handler/CustomRawAssetConverter.cs
+++ b/Assets/CatAsset/Runtime/Handler/CustomRawAssetConverter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CatAsset.Runtime
+{
+    /// <summary>
+    /// 自定义原生资源转换器的接口
+    /// </summary>
+    public interface ICustomRawAssetConverter
+    {
+        /// <summary>
+        /// 转换原生资源数据为指定类型的资源对象
+        /// </summary>
+        Task<object> Convert(byte[] bytes);
+    }
+
+    public abstract class BaseCustomRawAssetConverter<T> : ICustomRawAssetConverter
+    {
+        /// <inheritdoc cref="ICustomRawAssetConverter.Convert"/>
+        public abstract Task<T> Convert(byte[] bytes);
+        /// <inheritdoc />
+        async Task<object> ICustomRawAssetConverter.Convert(byte[] bytes)
+        {
+            return await Convert(bytes);
+        }
+    }
+
+
+    public delegate T CustomRawAssetConverterFunc<T>(byte[] bytes);
+
+    public delegate
+#if !UNITASK
+        Task<T>
+#else
+        UniTask<T>
+#endif
+        AsyncCustomRawAssetConverterFunc<T>(byte[] bytes);
+
+    internal sealed class AnonymousCustomRawAssetConverter<T> : ICustomRawAssetConverter
+    {
+        private readonly object convert;
+
+        internal AnonymousCustomRawAssetConverter(AsyncCustomRawAssetConverterFunc<T> convert) =>
+            this.convert = convert;
+
+        internal AnonymousCustomRawAssetConverter(CustomRawAssetConverterFunc<T> convert) =>
+            this.convert = convert;
+
+        /// <inheritdoc />
+        public async Task<object> Convert(byte[] bytes)
+        {
+            if (convert is AsyncCustomRawAssetConverterFunc<T> asyncConverter)
+            {
+                return await asyncConverter(bytes);
+            }
+            else if (convert is CustomRawAssetConverterFunc<T> converter)
+            {
+                return converter(bytes);
+            }
+
+            throw new InvalidOperationException("Invalid converter type");
+        }
+    }
+
+    public static class CustomRawAssetConverter
+    {
+        /// <summary>
+        /// 创建一个同步的自定义原生资源转换器
+        /// </summary>
+        public static ICustomRawAssetConverter Create<T>(CustomRawAssetConverterFunc<T> converter)
+        {
+            _ = converter ?? throw new ArgumentNullException("Cannot create a null converter", nameof(converter));
+            return new AnonymousCustomRawAssetConverter<T>(converter);
+        }
+
+        /// <summary>
+        /// 创建一个支持异步的自定义原生资源转换器，该方法本身不是异步的
+        /// </summary>
+        public static ICustomRawAssetConverter CreateAsync<T>(AsyncCustomRawAssetConverterFunc<T> converter)
+        {
+            _ = converter ?? throw new ArgumentNullException("Cannot create a null async converter", nameof(converter));
+            return new AnonymousCustomRawAssetConverter<T>(converter);
+        }
+    }
+}

--- a/Assets/CatAsset/Runtime/Handler/CustomRawAssetConverter.cs.meta
+++ b/Assets/CatAsset/Runtime/Handler/CustomRawAssetConverter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e2cc813dfed54d9596e29481e27b8edf
+timeCreated: 1772977207


### PR DESCRIPTION
## Summary
添加了支持异步（返回 Task<object>）的原生资源转换器，希望尽可能没有破坏原有的 Api 定义与使用方式

## Api diff
```diff
- public delegate object CustomRawAssetConverter(byte[] bytes);

+ public interface ICustomRawAssetConverter
+ {
+        Task<object> Convert(byte[] bytes);
+ }

+ public delegate void AssetConvertedCallback<T>(T asset);

abstract class AssetHandler
{
-    public T AssetAs<T>();
+    public void AssetAs<T>(AssetConvertedCallback<T> onCompleted).
}
```

```diff
+ public delegate T CustomRawAssetConverterFunc<T>(byte[] bytes);

+ public delegate
+ #if !UNITASK
+         Task<T>
+ #else
+         UniTask<T>
+ #endif
+         AsyncCustomRawAssetConverterFunc<T>(byte[] bytes);

+ public abstract class BaseCustomRawAssetConverter<T> : ICustomRawAssetConverter
+ {
+     public abstract Task<T> Convert(byte[] bytes);
+ }

+ public static class CustomRawAssetConverter
+ {
+     public static ICustomRawAssetConverter Create<T>(CustomRawAssetConverterFunc<T> converter);
+     public static ICustomRawAssetConverter CreateAsync<T>(AsyncCustomRawAssetConverterFunc<T> converter);
+ }
```

```diff
class AssetManager
{
-    public static void RegisterCustomRawAssetConverter(Type type, CustomRawAssetConverter converter);
+    public static void RegisterCustomRawAssetConverter(Type type, ICustomRawAssetConverter converter);

+    public static void RegisterCustomRawAssetConverter<T>(CustomRawAssetConverterFunc<T> converter);
+    public static void RegisterAsyncCustomRawAssetConverter<T>(AsyncCustomRawAssetConverterFunc<T> converter);
}
```

## 一些 Api 设计抉择的历史版本
在最开始设计 Api 时没有在方法命名上区分 async 与 sync 的差异，使用了类似下面这样的方式
```cs
public static void RegisterCustomRawAssetConverter<T>(CustomRawAssetConverterFunc<T> converter);
public static void RegisterCustomRawAssetConverter<T>(AsyncCustomRawAssetConverterFunc<T> converter);
```

该方法在使用具名方法时，非常符合设计目标，但在匿名委托下，非常依赖匿名委托的方法签名与返回值，案例如下
```cs
// 假设如下为同步转换器，可以正常识别方法重载
RegisterCustomRawAssetConverter(bytes =>
{
    var result = ...
    return result;
});

// 使用 async 标记匿名函数时，可以正常识别异步相关重载
RegisterCustomRawAssetConverter(async bytes =>
{
    var result = await ...
    return result;
});

// 极端情况，出现二义性问题，编译器重载决议失败
RegisterCustomRawAssetConverter(bytes =>
{
    return null;
});
```

而且在后续审视 Api diff 时，主观觉得没有显著的 async 标识，可能会导致使用 api 本身变成一种需要注意函数签名的陷阱问题

在综合考虑后，我选择使用文档注释来标记 `CustomRawAssetConverter` 静态类中的工厂方法，在预想的场景下，这个 api 不应该被外部经常使用，所以我在这里留下了一个坑，使用 `CustomRawAssetConverter.CreateAsync` 来创建匿名异步转换器

虽然这与 .net 生态中约定俗成的 Async 后缀用法含义不同并且很有可能造成歧义，但在 `CustomRawAssetConverter.CreateAsyncConverter` 和当前命名之间，我更倾向选择没有重复单词，且长度更短的命名

如果觉得长命名方案更合适，我可以继续调整这个 pr